### PR TITLE
Building libproj from source on Linux

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -10,13 +10,12 @@ libproj = library_dependency("libproj", aliases = ["libproj"])
 @linux_only begin
 
 	
-	
 	# AptGet's LibProj is old
 	#provides(AptGet, "libproj0", libproj, os = :Linux)  
 
 	# so download a newer version
 	libsrc = "http://download.osgeo.org/proj"
-	libproj_ver = "4.9.1" # from source http://download.osgeo.org/proj/
+	libproj_ver = "4.9.2" # from source http://download.osgeo.org/proj/
 	libproj_name = "proj-$(libproj_ver).tar.gz"
 
 	# and build it from source

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -24,18 +24,17 @@ const libproj_ver = "4.9.1"
 			GetSources(libproj)
 			CreateDirectory(builddir)
 			@build_steps begin
-				CreateDirectory(prefix)
-				println(srcdir)
-				cd(srcdir)
-				FileRule(joinpath(prefix,"lib","libproj.so"), @build_steps begin
-					#`./configure --prefix="$prefix"`
-					`./configure`   # installs to usr/local/lib by default
+				ChangeDirectory(builddir)
+				FileRule(joinpath("/usr", "local", "lib","libproj.so"), @build_steps begin
+					#`echo Configuring: $(srcdir)/configure --prefix=$(prefix)`
+					#`$(srcdir)/configure --prefix=$(prefix)`
+					`$(srcdir)/configure`
+					`echo Making`
 					`make`
-					`make install`
-					srcdir
+					`sudo make install`
 				end)
 			end
-		end),libproj, os = :Linux)
+		end), libproj, os = :Linux)
 end
 
 @osx_only begin

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -35,9 +35,10 @@ libproj = library_dependency("libproj", aliases = ["libproj"])
 				ChangeDirectory(builddir)
 				FileRule(joinpath(libdir, "libproj.so"), 
 				@build_steps begin
-					`$(srcdir)/configure --prefix=$(prefix)`
+					ChangeDirectory(srcdir)
+					`./configure --prefix=$(prefix)`
 					`make`
-					#`sudo make install`
+					`make install`
 				end)
 			end
 		end), libproj, os = :Linux, installed_libpath=libdir)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -25,11 +25,8 @@ const libproj_ver = "4.9.1"
 			CreateDirectory(builddir)
 			@build_steps begin
 				ChangeDirectory(builddir)
-				FileRule(joinpath("/usr", "local", "lib","libproj.so"), @build_steps begin
-					#`echo Configuring: $(srcdir)/configure --prefix=$(prefix)`
-					#`$(srcdir)/configure --prefix=$(prefix)`
-					`$(srcdir)/configure`
-					`echo Making`
+				FileRule(joinpath(prefix, "lib","libproj.so"), @build_steps begin
+					`$(srcdir)/configure --prefix=$(prefix)`
 					`make`
 					`sudo make install`
 				end)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -5,33 +5,42 @@ using BinDeps
 #@BinDeps.if_install begin
 
 libproj = library_dependency("libproj", aliases = ["libproj"])
-const libproj_ver = "4.9.1"
+
 
 @linux_only begin
+
+	
 	
 	# AptGet's LibProj is old
 	#provides(AptGet, "libproj0", libproj, os = :Linux)  
 
 	# so download a newer version
-	provides(Sources, URI("http://download.osgeo.org/proj/proj-$(libproj_ver).tar.gz"), libproj, os = :Linux)
+	libsrc = "http://download.osgeo.org/proj"
+	libproj_ver = "4.9.1" # from source http://download.osgeo.org/proj/
+	libproj_name = "proj-$(libproj_ver).tar.gz"
 
-	# build it from source
+	# and build it from source
 	prefix   = joinpath(BinDeps.depsdir(libproj), "usr")
 	srcdir   = joinpath(BinDeps.depsdir(libproj), "src", "proj-$(libproj_ver)")
 	builddir = joinpath(BinDeps.depsdir(libproj), "builds", "libproj-$(libproj_ver)_version")
+	libdir   = joinpath(prefix, "lib")
+
+	provides(Sources, URI(joinpath(libsrc, libproj_name)), libproj, os = :Linux, installed_libpath=libdir)
+
 	provides(BuildProcess,
 		(@build_steps begin
 			GetSources(libproj)
 			CreateDirectory(builddir)
 			@build_steps begin
 				ChangeDirectory(builddir)
-				FileRule(joinpath(prefix, "lib","libproj.so"), @build_steps begin
+				FileRule(joinpath(libdir, "libproj.so"), 
+				@build_steps begin
 					`$(srcdir)/configure --prefix=$(prefix)`
 					`make`
-					`sudo make install`
+					#`sudo make install`
 				end)
 			end
-		end), libproj, os = :Linux)
+		end), libproj, os = :Linux, installed_libpath=libdir)
 end
 
 @osx_only begin

--- a/src/Proj4.jl
+++ b/src/Proj4.jl
@@ -1,4 +1,5 @@
-VERSION >= v"0.4.0-dev+6521" && __precompile__(true)  # BinDeps is a little slow
+# VERSION >= v"0.4.0-dev+6521" && __precompile__(true)  # BinDeps is a little slow
+# The above causes the warning: eval from module __anon__ to Proj4
 
 module Proj4
 

--- a/src/Proj4.jl
+++ b/src/Proj4.jl
@@ -2,10 +2,15 @@ module Proj4
 
 # TODO (cjf): Automatically declare libproj using BinDeps.  Make sure it
 # doesn't hurt package load time (probably requires precompilation)
-#using BinDeps
-#@BinDeps.load_dependencies
+using BinDeps
+@BinDeps.load_dependencies
 
-const libproj = "libproj"
+
+@linux_only begin
+	push!(Libdl.DL_LOAD_PATH, dirname(Proj4.libproj[1][end]))
+end
+const libproj_str = "libproj"    # there must be a better way...
+
 
 export Projection, # proj_types.jl
        transform, transform!,  # proj_functions.jl

--- a/src/Proj4.jl
+++ b/src/Proj4.jl
@@ -1,16 +1,15 @@
+VERSION >= v"0.4.0-dev+6521" && __precompile__(true)  # BinDeps is a little slow
+
 module Proj4
 
-# TODO (cjf): Automatically declare libproj using BinDeps.  Make sure it
-# doesn't hurt package load time (probably requires precompilation)
+
 using BinDeps
 @BinDeps.load_dependencies
-
 
 @linux_only begin
 	push!(Libdl.DL_LOAD_PATH, dirname(Proj4.libproj[1][end]))
 end
 const libproj_str = "libproj"    # there must be a better way...
-
 
 export Projection, # proj_types.jl
        transform, transform!,  # proj_functions.jl

--- a/src/proj_capi.jl
+++ b/src/proj_capi.jl
@@ -15,7 +15,7 @@ end
 
 @doc "forward projection from Lat/Lon to X/Y (only supports 2 dimensions)" ->
 function _fwd!(lonlat::Vector{Cdouble}, proj_ptr::Ptr{Void})
-    xy = ccall((:pj_fwd, libproj), ProjUV, (ProjUV, Ptr{Void}), ProjUV(lonlat[1], lonlat[2]), proj_ptr)
+    xy = ccall((:pj_fwd, libproj_str), ProjUV, (ProjUV, Ptr{Void}), ProjUV(lonlat[1], lonlat[2]), proj_ptr)
     _errno() == 0 || error("forward projection error: $(_strerrno())")
     lonlat[1] = xy.u; lonlat[2] = xy.v
     lonlat
@@ -24,7 +24,7 @@ end
 @doc "Row-wise projection from Lat/Lon to X/Y (only supports 2 dimensions)" ->
 function _fwd!(lonlat::Array{Cdouble,2}, proj_ptr::Ptr{Void})
     for i=1:size(lonlat,1)
-        xy = ccall((:pj_fwd, libproj), ProjUV, (ProjUV, Ptr{Void}),
+        xy = ccall((:pj_fwd, libproj_str), ProjUV, (ProjUV, Ptr{Void}),
                    ProjUV(lonlat[i,1], lonlat[i,2]), proj_ptr)
         lonlat[i,1] = xy.u; lonlat[i,2] = xy.v
     end
@@ -34,7 +34,7 @@ end
 
 @doc "inverse projection from X/Y to Lat/Lon (only supports 2 dimensions)" ->
 function _inv!(xy::Vector{Cdouble}, proj_ptr::Ptr{Void})
-    lonlat = ccall((:pj_inv, libproj), ProjUV, (ProjUV, Ptr{Void}),
+    lonlat = ccall((:pj_inv, libproj_str), ProjUV, (ProjUV, Ptr{Void}),
                    ProjUV(xy[1], xy[2]), proj_ptr)
     _errno() == 0 || error("inverse projection error: $(_strerrno())")
     xy[1] = lonlat.u; xy[2] = lonlat.v
@@ -44,7 +44,7 @@ end
 @doc "Row-wise projection from X/Y to Lat/Lon (only supports 2 dimensions)" ->
 function _inv!(xy::Array{Cdouble,2}, proj_ptr::Ptr{Void})
     for i=1:size(xy,1)
-        lonlat = ccall((:pj_inv, libproj), ProjUV, (ProjUV, Ptr{Void}),
+        lonlat = ccall((:pj_inv, libproj_str), ProjUV, (ProjUV, Ptr{Void}),
                        ProjUV(xy[i,1], xy[i,2]), proj_ptr)
         xy[i,1] = lonlat.u; xy[i,2] = lonlat.v
     end
@@ -53,7 +53,7 @@ function _inv!(xy::Array{Cdouble,2}, proj_ptr::Ptr{Void})
 end
 
 function _init_plus(proj_string::ASCIIString)
-    proj_ptr = ccall((:pj_init_plus, libproj), Ptr{Void}, (Cstring,), proj_string)
+    proj_ptr = ccall((:pj_init_plus, libproj_str), Ptr{Void}, (Cstring,), proj_string)
     if proj_ptr == C_NULL
         # TODO: use context?
         error("Could not parse projection: \"$proj_string\": $(_strerrno())")
@@ -64,12 +64,12 @@ end
 @doc "Free C datastructure associated with a projection. For internal use!" ->
 function _free(proj_ptr::Ptr{Void})
     @assert proj_ptr != C_NULL
-    ccall((:pj_free, libproj), Void, (Ptr{Void},), proj_ptr)
+    ccall((:pj_free, libproj_str), Void, (Ptr{Void},), proj_ptr)
 end
 
 @doc "Get human readable error string from proj.4 error code" ->
 function _strerrno(code::Cint)
-    bytestring(ccall((:pj_strerrno, libproj), Cstring, (Cint,), code))
+    bytestring(ccall((:pj_strerrno, libproj_str), Cstring, (Cint,), code))
 end
 
 @doc "Get global errno string in human readable form" ->
@@ -79,21 +79,21 @@ end
 
 @doc "Get error number"
 function _errno()
-    unsafe_load(ccall((:pj_get_errno_ref, libproj), Ptr{Cint}, ()))
+    unsafe_load(ccall((:pj_get_errno_ref, libproj_str), Ptr{Cint}, ()))
 end
 
 @doc "Get projection definition string in the proj.4 plus format" ->
 function _get_def(proj_ptr::Ptr{Void})
     @assert proj_ptr != C_NULL
     opts = 0 # Apparently obsolete argument, not used in current proj source
-    bytestring(ccall((:pj_get_def, libproj), Cstring, (Ptr{Void}, Cint), proj_ptr, opts))
+    bytestring(ccall((:pj_get_def, libproj_str), Cstring, (Ptr{Void}, Cint), proj_ptr, opts))
 end
 
-@doc "Low level interface to libproj transform, C_NULL can be passed in for z, if it's 2-dimensional" ->
+@doc "Low level interface to libproj_str transform, C_NULL can be passed in for z, if it's 2-dimensional" ->
 function _transform!(src_ptr::Ptr{Void}, dest_ptr::Ptr{Void}, point_count::Integer, point_stride::Integer,
                      x::Ptr{Cdouble}, y::Ptr{Cdouble}, z::Ptr{Cdouble})
     @assert src_ptr != C_NULL && dest_ptr != C_NULL
-    err = ccall((:pj_transform, libproj), Cint, (Ptr{Void}, Ptr{Void}, Clong, Cint, Ptr{Cdouble}, Ptr{Cdouble},
+    err = ccall((:pj_transform, libproj_str), Cint, (Ptr{Void}, Ptr{Void}, Clong, Cint, Ptr{Cdouble}, Ptr{Cdouble},
                 Ptr{Cdouble}), src_ptr, dest_ptr, point_count, point_stride, x, y, z)
     err != 0 && error("transform error: $(_strerrno(err))")
 end
@@ -125,17 +125,17 @@ end
 
 function _is_latlong(proj_ptr::Ptr{Void})
     @assert proj_ptr != C_NULL
-    ccall((:pj_is_latlong, libproj), Cint, (Ptr{Void},), proj_ptr) != 0
+    ccall((:pj_is_latlong, libproj_str), Cint, (Ptr{Void},), proj_ptr) != 0
 end
 
 function _is_geocent(proj_ptr::Ptr{Void})
     @assert proj_ptr != C_NULL
-    ccall((:pj_is_geocent, libproj), Cint, (Ptr{Void},), proj_ptr) != 0
+    ccall((:pj_is_geocent, libproj_str), Cint, (Ptr{Void},), proj_ptr) != 0
 end
 
-@doc "Get a string describing the underlying version of libproj in use" ->
+@doc "Get a string describing the underlying version of libproj_str in use" ->
 function _get_release()
-    bytestring(ccall((:pj_get_release, libproj), Cstring, ()))
+    bytestring(ccall((:pj_get_release, libproj_str), Cstring, ()))
 end
 
 @doc """
@@ -148,14 +148,14 @@ Fetch the internal definition of the spheroid as a tuple (a, es), where
 function _get_spheroid_defn(proj_ptr::Ptr{Void})
     major_axis = Ref{Cdouble}()
     eccentricity_squared = Ref{Cdouble}()
-    ccall((:pj_get_spheroid_defn, libproj), Void, (Ptr{Void}, Ptr{Cdouble}, Ptr{Cdouble}),
+    ccall((:pj_get_spheroid_defn, libproj_str), Void, (Ptr{Void}, Ptr{Cdouble}, Ptr{Cdouble}),
           proj_ptr, major_axis, eccentricity_squared)
     major_axis[], eccentricity_squared[]
 end
 
 @doc "Returns true if the two datums are identical, otherwise false." ->
 function _compare_datums(p1_ptr::Ptr{Void}, p2_ptr::Ptr{Void})
-    Bool(ccall((:pj_compare_datums, libproj), Cint, (Ptr{Void}, Ptr{Void}), p1_ptr, p2_ptr))
+    Bool(ccall((:pj_compare_datums, libproj_str), Cint, (Ptr{Void}, Ptr{Void}), p1_ptr, p2_ptr))
 end
 
 # Unused/untested
@@ -165,5 +165,5 @@ end
 # If the coordinate system passed in is latlong, a clone of the same will be returned.
 # """ ->
 # function _latlong_from_proj(proj_ptr::Ptr{Void})
-#     ccall((:pj_latlong_from_proj, libproj), Ptr{Void}, (Ptr{Void},), proj_ptr)
+#     ccall((:pj_latlong_from_proj, libproj_str), Ptr{Void}, (Ptr{Void},), proj_ptr)
 # end

--- a/src/proj_geodesic.jl
+++ b/src/proj_geodesic.jl
@@ -87,7 +87,7 @@ Reference: equations (1)-(3) of
 """ ->
 function geod_geodesic(a::Cdouble, f::Cdouble)
     geod = geod_geodesic()
-    ccall((:geod_init, libproj), Void, (Ptr{Void},Cdouble,Cdouble),
+    ccall((:geod_init, libproj_str), Void, (Ptr{Void},Cdouble,Cdouble),
           pointer_from_objref(geod), a, f)
     geod
 end
@@ -116,7 +116,7 @@ Remarks:
 function _geod_direct!(geod::geod_geodesic, lonlat::Vector{Cdouble}, azimuth::Cdouble, distance::Cdouble)
     p = pointer(lonlat)
     azi = Ref{Cdouble}() # the (forward) azimuth at the destination
-    ccall((:geod_direct, libproj),Void,(Ptr{Void},Cdouble,Cdouble,Cdouble,Cdouble,Ptr{Cdouble},Ptr{Cdouble},
+    ccall((:geod_direct, libproj_str),Void,(Ptr{Void},Cdouble,Cdouble,Cdouble,Cdouble,Ptr{Cdouble},Ptr{Cdouble},
           Ptr{Cdouble}), pointer_from_objref(geod), lonlat[2], lonlat[1], azimuth, distance, p+sizeof(Cdouble), p, azi)
     lonlat, azi[]
 end
@@ -145,7 +145,7 @@ function _geod_inverse(geod::geod_geodesic, lonlat1::Vector{Cdouble}, lonlat2::V
     dist = Ref{Cdouble}()
     azi1 = Ref{Cdouble}()
     azi2 = Ref{Cdouble}()
-    ccall((:geod_inverse, libproj), Void, (Ptr{Void},Cdouble,Cdouble,Cdouble,
+    ccall((:geod_inverse, libproj_str), Void, (Ptr{Void},Cdouble,Cdouble,Cdouble,
           Cdouble,Ptr{Cdouble},Ptr{Cdouble},Ptr{Cdouble}),
           pointer_from_objref(geod), lonlat1[2], lonlat1[1], lonlat2[2], lonlat2[1], dist, azi1, azi2)
     dist[], azi1[], azi2[]


### PR DESCRIPTION
###### The Good:

- It'll build Proj4 from source allowing for newer Proj4 versions than apt-get

###### The Bad:

- No minimum version for the libproj dependency (if you already have an old libproj version it won't build a newer one)
- I've only done it for Linux
- Slower load time and pre-compiling whinges.  
- There's got to be a way to get the library name and path from the dependency entry

###### The Other

- had to rename the library name variable to not conflict with the dependency entry
